### PR TITLE
fix: ssr request

### DIFF
--- a/lua/rust-tools/ssr.lua
+++ b/lua/rust-tools/ssr.lua
@@ -10,19 +10,27 @@ local function get_opts(query)
   return opts
 end
 
-local function handler(err, result)
+local function handler(err, result, ctx)
   if err then
     error("Could not execute request to server: " .. err.message)
     return
   end
 
-  vim.lsp.util.apply_workspace_edit(result)
+  local client = vim.lsp.get_client_by_id(ctx.client_id)
+  if not client then
+    return
+  end
+
+  vim.lsp.util.apply_workspace_edit(result, client.offset_encoding)
 end
 
 function M.ssr(query)
   if not query then
     vim.ui.input({ prompt = "Enter query: " }, function(input)
       query = input
+      if query then
+        M.ssr(query)
+      end
     end)
   end
 


### PR DESCRIPTION
The PR has done two things:

1. Fixed the issue where calling `applly_workspace_edit` failed in the SSR handler.
2. Fixed the issue where the ssr function became ineffective when `vim.ui.input` was replaced by dressing or other plugins.